### PR TITLE
apply build tags (-tags) to default go build context

### DIFF
--- a/gotest/gotest.go
+++ b/gotest/gotest.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/visualfc/gotools/pkg/command"
+	"golang.org/x/tools/go/buildutil"
 )
 
 var Command = &command.Command{
@@ -103,7 +104,10 @@ func ApplyBuildTags() {
 	nexttag := false
 	for _, arg := range os.Args[1:] {
 		if nexttag {
-			build.Default.BuildTags = strings.Split(arg, ",")
+			var tags buildutil.TagsFlag
+			tags.Set(arg)
+
+			build.Default.BuildTags = tags
 			nexttag = false
 			continue
 		}

--- a/gotest/gotest.go
+++ b/gotest/gotest.go
@@ -25,9 +25,10 @@ var Command = &command.Command{
 var testFileName string
 var testFileArgs string
 
-//func init() {
-//	Command.Flag.StringVar(&testFileName, "f", "", "test go filename")
-//}
+func init() {
+	//Command.Flag.StringVar(&testFileName, "f", "", "test go filename")
+	ApplyBuildTags()
+}
 
 func runGotest(cmd *command.Command, args []string) error {
 	index := -1
@@ -96,4 +97,18 @@ func runGotest(cmd *command.Command, args []string) error {
 	command.Stderr = os.Stderr
 
 	return command.Run()
+}
+
+func ApplyBuildTags() {
+	nexttag := false
+	for _, arg := range os.Args[1:] {
+		if nexttag {
+			build.Default.BuildTags = strings.Split(arg, ",")
+			nexttag = false
+			continue
+		}
+		if arg == "-tags" {
+			nexttag = true
+		}
+	}
 }


### PR DESCRIPTION
Gotools didn't work with custom build tags