### PR TITLE
replace derekparker dependencies by go-delve

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -4,7 +4,7 @@
 	"GodepVersion": "v80",
 	"Deps": [
 		{
-			"ImportPath": "github.com/derekparker/delve/pkg/goversion",
+			"ImportPath": "github.com/go-delve/delve/pkg/goversion",
 			"Comment": "v1.1.0-84-ga86711f",
 			"Rev": "a86711f547fdfef6a2c1bc5755569f9b25b64323"
 		},

--- a/debugflags/debugflags.go
+++ b/debugflags/debugflags.go
@@ -7,7 +7,7 @@ package debugflags
 import (
 	"runtime"
 
-	"github.com/derekparker/delve/pkg/goversion"
+	"github.com/go-delve/delve/pkg/goversion"
 	"github.com/visualfc/gotools/pkg/command"
 )
 

--- a/godoc/godoc.go
+++ b/godoc/godoc.go
@@ -7,7 +7,7 @@ package godoc
 import (
 	"os/exec"
 
-	"github.com/derekparker/delve/pkg/goversion"
+	"github.com/go-delve/delve/pkg/goversion"
 	"github.com/visualfc/gotools/pkg/command"
 )
 


### PR DESCRIPTION
Replace the delve location to be able to install using newest versions of Golang. Go module is complaining about it.