### PR TITLE
update pty to support more os and loongarch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/visualfc/gotools
 go 1.13
 
 require (
-	github.com/creack/pty v1.1.9
+	github.com/creack/pty v1.1.21
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/visualfc/gomod v0.1.2
 	github.com/visualfc/goversion v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/creack/pty v1.1.9 h1:uDmaGzcdjhF4i/plgjmEsriH11Y0o7RKapEf/LDaM3w=
-github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/creack/pty v1.1.21 h1:1/QdRyBaHHJP61QkWMXlOIBfsgdDeeKfK8SYVUWJKf0=
+github.com/creack/pty v1.1.21/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/visualfc/gomod v0.1.2 h1:7qfPmifcA8r/0ZTpTPZQqsm5aJUiQ/EeyHEENPyywDg=


### PR DESCRIPTION
Go package pty has added support for loongarch and several operating system during 1.1.9 and 1.1.21. To build liteide on loongarch pc, pty version should be updated.